### PR TITLE
Can't test the steps yet, but clarifying some language

### DIFF
--- a/docs/README-datatype.md
+++ b/docs/README-datatype.md
@@ -1,15 +1,16 @@
 # Adding a new datatype to the Workspace
 
-KBase data objects are strongly typed, meaning that the datatype has a structure with required and optional fields.  This structure is enforced during creation.
-You can add types to the system.  However, please consult the [Project Guides](https://github.com/kbase/project_guides) before trying to add new types.
+KBase data objects are strongly typed, meaning that each datatype has a structure with required and optional fields.  This structure is enforced during creation.
 
-The basic steps to adding a new type are: 1) login and connect to the workspace 2) Request and approve the new module (i.e. namespace)  3) Create the typespec 4) Register, commit and release the typespec
+You can add new types to KBase, but please consult the [Project Guides](https://github.com/kbase/project_guides) before you begin.
 
-We will now walk through each step.  We will register a new module call MyModule.
+The basic steps to adding a new type are: 1) Login and connect to the workspace; 2) Request and approve the new module (e.g., namespace);  3) Create the typespec; 4) Register, commit and release the typespec
+
+We will now walk through each step.  In this example, we will register a new module called MyModule.
 
 ## Connect to the workspace
 
-If you have the workspace tools installed locally you can try using them.  Otherwise you can use the client.sh helper script to start a client session
+If you have the workspace tools installed locally you can try using them.  Otherwise you can use the client.sh helper script to start a client session:
 
     ./client.sh
     . ./path/to/site.cfg


### PR DESCRIPTION
I have some questions about this document.
1.  The title is"adding a new data type ", but then you switched to talking about "module." I think you mean the module that represents the type and its type spec and perhaps the methods for accessing the type, But we should clarify this usage.
2. The second of the "basic steps to adding a new type" said "Request and approve the new module (i.e. namespace)". I changed i.e. to e.g. (i.e. means "in other words"; e.g. means "for example"; many people mix those up) but in fact I'm not totally sure that's what you meant. Maybe there is something that you're supposed to do about the namespace?
3. In the final step, are you supposed to run ws-typespec-register twice, the second time with --commit?
